### PR TITLE
Fix missing workspace_id exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,8 +104,13 @@ def get_active_windows():
     screen.force_update()  # recommended per Wnck documentation
 
     windows = screen.get_windows_stacked()
-    for window in windows:
-        window.workspace_id = window.get_workspace().get_number() + 1
+    for i, window in enumerate(windows):
+        try:
+            window.workspace_id = window.get_workspace().get_number() + 1
+        except AttributeError:
+            logger.debug("A window ({}) is not attached to any workspace".format(window.get_name()))
+            # remove the window from the list to avoid NoneType on workspace_id
+            del(windows[i])
 
     # clean up Wnck (saves resources, check documentation)
     screen = None


### PR DESCRIPTION
If the windows is not attached to a workspace, the call to `get_number()` would return `None`. Once this happen, future accesses to `window.workspace_id` would trigger an exception.

The proposed fix catch the exception and remove the offending window, as we can expect that a window not attached to a Workspace cannot be switched to.

In elementaryOS this behaviour is exhibited with the Plank, the dock application.

Fixes #1