### PR TITLE
Remove python3 incompatible code

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,8 +47,8 @@ class KeywordQueryEventListener(EventListener):
     def is_name_in_query(self, window, query):
         # TODO implement fuzzy search
         full_name = (window.get_name() + window.get_class_group_name()
-                     ).decode('utf-8').lower()
-        return query.decode('utf-8').lower() in full_name
+                     ).lower()
+        return query.lower() in full_name
 
     def create_result_item(self, window):
         # icon as Pixbuf is not supported; saving it on the disk as a workaround


### PR DESCRIPTION
Running this extension under Python 3 prompted this error:
`AttributeError: 'str' object has no attribute 'decode'`

The call to `decode` can be removed without issues on Python 3.